### PR TITLE
Fix issue with guild channels not being retrieved

### DIFF
--- a/wp-discord/admin/class-wp-discord-admin.php
+++ b/wp-discord/admin/class-wp-discord-admin.php
@@ -168,7 +168,7 @@ class WP_Discord_Admin
                     $settings_tab->auth_link = 'https://discordapp.com/oauth2/authorize?client_id=' . $settings_tab->client_id . '&scope=bot&permissions=0x20000000';
                     break;
                 case 'settings':
-                    $settings_tab->channels = $this->guild->get_channels('text');
+                    $settings_tab->channels = $this->guild->get_channels(0);
                     break;
             }
 

--- a/wp-discord/includes/class-wp-discord-guild.php
+++ b/wp-discord/includes/class-wp-discord-guild.php
@@ -79,7 +79,7 @@ class WP_Discord_Guild
 
         $channels = json_decode($response);
 
-        if (!empty($type)) {
+        if (!is_null($type)) {
             foreach ($channels as $key => $channel) {
                 if ($channel->type !== $type) {
                     unset($channels[$key]);


### PR DESCRIPTION
Looks like the channel type returned by the API used to be text but has since been changed to an integer, so none were being found. Fixed by changing get_channels parameter from 'text' to 0.